### PR TITLE
Fix Android captive portal probe (204 on /generate_204)

### DIFF
--- a/src/RuntimeBuild/RuntimeBuildPortal.cpp
+++ b/src/RuntimeBuild/RuntimeBuildPortal.cpp
@@ -183,11 +183,18 @@ RuntimeBuildPortalResult runRuntimeBuildPortal() {
         }
     });
 
+    // Android's captive-portal probe: expects exactly 204 No Content to consider
+    // the network as having internet access and stop routing via mobile data.
     server.on("/generate_204", HTTP_GET, [&server]() {
-        server.sendHeader("Location", "http://192.168.4.1/", true);
-        server.send(302, "text/plain", "");
+        server.send(204, "text/plain", "");
     });
 
+    // Android alternative probe path.
+    server.on("/hotspot-detect.html", HTTP_GET, [&server]() {
+        server.send(204, "text/plain", "");
+    });
+
+    // Windows / older captive-portal redirect.
     server.on("/fwlink", HTTP_GET, [&server]() {
         server.sendHeader("Location", "http://192.168.4.1/", true);
         server.send(302, "text/plain", "");


### PR DESCRIPTION
## Problem
After connecting to the AP, Android detects "no internet" and silently routes all traffic (including to `192.168.4.1`) through mobile data. The browser shows "this site can't be reached" even though the ESP32's web server is running fine.

## Root cause
Android sends `GET /generate_204` as an internet connectivity probe. It expects exactly **`204 No Content`** to confirm internet access. We were returning a `302` redirect, which Android treats as "no internet" — so it keeps using cellular for all traffic.

## Fix
- `/generate_204` → `204 No Content` (was `302` redirect to `/`)
- `/hotspot-detect.html` → `204 No Content` (Android alternate probe path, new)
- `/fwlink` → `302` redirect kept for Windows captive portal compatibility