### PR TITLE
Fix captive portal WiFi binding: revert 204 to 302 on probe endpoints

### DIFF
--- a/src/RuntimeBuild/RuntimeBuildPortal.cpp
+++ b/src/RuntimeBuild/RuntimeBuildPortal.cpp
@@ -183,20 +183,29 @@ RuntimeBuildPortalResult runRuntimeBuildPortal() {
         }
     });
 
-    // Android's captive-portal probe: expects exactly 204 No Content to consider
-    // the network as having internet access and stop routing via mobile data.
-    server.on("/generate_204", HTTP_GET, [&server]() {
-        server.send(204, "text/plain", "");
+    // Android captive-portal probe. Returning 302 keeps the network in
+    // "captive portal" state so Android's sign-in WebView stays bound to
+    // the WiFi interface. Returning 204 would mark the network as "has
+    // internet" and cancel the WiFi binding, causing all subsequent requests
+    // (including the portal page load) to route through cellular.
+    server.on("/generate_204", HTTP_GET, [&apIp, &server]() {
+        String url = String("http://") + apIp.toString() + "/";
+        server.sendHeader("Location", url, true);
+        server.send(302, "text/plain", "");
     });
 
-    // Android alternative probe path.
-    server.on("/hotspot-detect.html", HTTP_GET, [&server]() {
-        server.send(204, "text/plain", "");
+    // iOS captive-portal probe. Returning anything other than the "Success"
+    // page triggers the captive portal popup and keeps the WebView WiFi-bound.
+    server.on("/hotspot-detect.html", HTTP_GET, [&apIp, &server]() {
+        String url = String("http://") + apIp.toString() + "/";
+        server.sendHeader("Location", url, true);
+        server.send(302, "text/plain", "");
     });
 
     // Windows / older captive-portal redirect.
-    server.on("/fwlink", HTTP_GET, [&server]() {
-        server.sendHeader("Location", "http://192.168.4.1/", true);
+    server.on("/fwlink", HTTP_GET, [&apIp, &server]() {
+        String url = String("http://") + apIp.toString() + "/";
+        server.sendHeader("Location", url, true);
         server.send(302, "text/plain", "");
     });
 
@@ -315,8 +324,9 @@ RuntimeBuildPortalResult runRuntimeBuildPortal() {
         submissionState.details = connected ? "Config saved. Wi-Fi connected." : "Config saved. Wi-Fi connect failed.";
     });
 
-    server.onNotFound([&server]() {
-        server.sendHeader("Location", "http://192.168.4.1/", true);
+    server.onNotFound([&apIp, &server]() {
+        String url = String("http://") + apIp.toString() + "/";
+        server.sendHeader("Location", url, true);
         server.send(302, "text/plain", "");
     });
 


### PR DESCRIPTION
## Problem
The "Sign in to network" popup appears on Android/iOS but the portal page doesn't load. Directly typing `http://192.168.4.1` also fails on mobile (works fine on laptop).

## Root cause
PR #27 changed `/generate_204` to return `204 No Content`. This was wrong:

- `204` tells Android **"internet is available"** → Android cancels the captive portal WiFi binding
- The sign-in WebView's page load (and all subsequent requests) then route through **cellular** instead of WiFi
- `192.168.4.1` is not reachable over cellular → page fails to load

## Fix
Return `302` redirect on all captive portal probe endpoints:
- `/generate_204` (Android) → `302` keeps the network in "captive portal" state → sign-in WebView stays bound to WiFi ✓
- `/hotspot-detect.html` (iOS) → `302` triggers captive portal popup with WiFi-bound WebView ✓
- `/fwlink` (Windows) → `302` (unchanged behavior)
- `onNotFound` → `302` (unchanged behavior)

Also replaces all hardcoded `192.168.4.1` redirect URLs with the runtime `apIp` value.